### PR TITLE
ntp-can-be-hostname

### DIFF
--- a/spec/bridge/spec/ntp.go
+++ b/spec/bridge/spec/ntp.go
@@ -3,5 +3,5 @@ package spec
 import "net"
 
 type NTP struct {
-	Servers []net.IP `json:"servers" yaml:"servers"`
+	Servers []string `json:"servers" yaml:"servers"`
 }

--- a/spec/bridge/spec/ntp.go
+++ b/spec/bridge/spec/ntp.go
@@ -1,7 +1,5 @@
 package spec
 
-import "net"
-
 type NTP struct {
 	Servers []string `json:"servers" yaml:"servers"`
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -33,9 +33,9 @@ func TestSpecYamlEncoding(t *testing.T) {
 					},
 				},
 				NTP: bridgespec.NTP{
-					Servers: []net.IP{
-						net.ParseIP("10.1.101.1"),
-						net.ParseIP("10.1.101.2"),
+					Servers: []string{
+						"10.1.101.1",
+						"10.1.101.2",
 					},
 				},
 			},


### PR DESCRIPTION
ntp can be defined as hostname so this restriction is not right :)